### PR TITLE
Improvements to DCGM Diag usage

### DIFF
--- a/Linux/src/gather_azhpc_vm_diagnostics.sh
+++ b/Linux/src/gather_azhpc_vm_diagnostics.sh
@@ -49,7 +49,6 @@ METADATA_URL='http://169.254.169.254/metadata/instance?api-version=2020-06-01'
 STREAM_URL='https://azhpcstor.blob.core.windows.net/diagtool-binaries/stream.tgz'
 LSVMBUS_URL='https://raw.githubusercontent.com/torvalds/linux/master/tools/hv/lsvmbus'
 SCRIPT_DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
-PKG_ROOT="$(dirname $SCRIPT_DIR)"
 
 # Mapping for stream benchmark(AMD only)
 declare -A CPU_LIST
@@ -71,7 +70,7 @@ Miscellaneous:
  -h, --help            display this help text and exit
 
 Execution Mode:
- --gpu-level=GPU_LEVEL dcgmi run level (default is 2)
+ --gpu-level=GPU_LEVEL dcgmi run level (default is 1)
  --mem-level=MEM_LEVEL set to 1 to run stream test (default is 0)
 
 For more information on this script and the data it gathers, visit its Github:
@@ -309,12 +308,25 @@ run_dcgm() {
         nvidia-smi -i "$id" -pm 1 >/dev/null
     done
 
-    print_log "Running 2min diagnostic"
-    dcgmi diag -r 2 >dcgm-diag-2.log
-
-    if [ "$GPU_LEVEL" -gt 2 ]; then
+    case "$GPU_LEVEL" in
+    1)
+        print_log "Running <1min diagnostic"
+        timeout 1m dcgmi diag -r 1 >dcgm-diag.log
+        ;;
+    2)
+        print_log "Running 2min diagnostic"
+        timeout 5m dcgmi diag -r 2 >dcgm-diag.log
+        ;;
+    3)
         print_log "Running 12min diagnostic"
-        dcgmi diag -r 3 >dcgm-diag-3.log
+        timeout 20m dcgmi diag -r 3 >dcgm-diag.log
+        ;;
+    *)
+        print_log "Invalid run-level for dcgm"
+        ;;
+    esac
+    if [ $? -eq 124 ]; then
+        print_log "DCGM timed out"
     fi
 
 

--- a/Linux/src/gather_azhpc_vm_diagnostics.sh
+++ b/Linux/src/gather_azhpc_vm_diagnostics.sh
@@ -310,15 +310,15 @@ run_dcgm() {
 
     case "$GPU_LEVEL" in
     1)
-        print_log "Running <1min diagnostic"
+        print_log "Running GPU diagnostics Level 1 (~ < 1 min)"
         timeout 1m dcgmi diag -r 1 >dcgm-diag.log
         ;;
     2)
-        print_log "Running 2min diagnostic"
+        print_log "Running GPU diagnostics Level 2 (~ 2 min)"
         timeout 5m dcgmi diag -r 2 >dcgm-diag.log
         ;;
     3)
-        print_log "Running 12min diagnostic"
+        print_log "Running GPU diagnostics Level 3 (~ 12 min)"
         timeout 20m dcgmi diag -r 3 >dcgm-diag.log
         ;;
     *)

--- a/Linux/test/run_tests.sh
+++ b/Linux/test/run_tests.sh
@@ -27,8 +27,7 @@ NVIDIA_EXT_FILENAMES="Nvidia/nvidia-vmext-status"
 
 NVIDIA_FOLDER="Nvidia/"
 
-DCGM_2_FILENAMES="Nvidia/dcgm-diag-2.log"
-DCGM_3_FILENAMES="Nvidia/dcgm-diag-3.log"
+DCGM_FILENAMES="Nvidia/dcgm-diag.log"
 
 MEMORY_FILENAMES="Memory/
 Memory/stream.txt"
@@ -176,7 +175,7 @@ fi
 if [ "$NVIDIA_PRESENT" = true ];then
     BASE_FILENAMES=$(cat <(echo "$BASE_FILENAMES") <(echo "$NVIDIA_FILENAMES"))
     if [ "$DCGM_INSTALLED" = true ];then
-        BASE_FILENAMES=$(cat <(echo "$BASE_FILENAMES") <(echo "$DCGM_2_FILENAMES"))
+        BASE_FILENAMES=$(cat <(echo "$BASE_FILENAMES") <(echo "$DCGM_FILENAMES"))
     fi
 fi
 
@@ -184,13 +183,7 @@ if [ "$NVIDIA_EXT_PRESENT" = true -o "$NVIDIA_PRESENT" = true ];then
     BASE_FILENAMES=$(cat <(echo "$BASE_FILENAMES") <(echo "$NVIDIA_FOLDER"))
 fi
 
-if [ "$DCGM_INSTALLED" != true ]; then
-    DCGM_3_FILENAMES=""
-fi
-
 overall_retcode=0
-
-
 
 # zero-output runs
 echo 'Testing without sudo'
@@ -230,6 +223,6 @@ sudo_basic_script_test --mem-level=1 "$MEMORY_FILENAMES"
 
 # raised gpu-level
 echo 'Testing with --gpu-level=3'
-sudo_basic_script_test --gpu-level=3 "$DCGM_3_FILENAMES"
+sudo_basic_script_test --gpu-level=3
 
 exit $overall_retcode

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This section describes the output of the script and the configuration options av
 | -V | --version |  | display version information and exit | --version | Outputs 0.0.1 |
 | -h | --help |  | display help text | -h | Outputs the help message |
 | -v | --verbose |  | verbose output | --verbose | Enables more verbose terminal output |
-|  | --gpu-level | 2 (default) or 3 | GPU diagnostics run-level | --gpu-level=3 | Sets dcgmi run-level to 3 |
+|  | --gpu-level | 1 (default), 2, or 3 | GPU diagnostics run-level | --gpu-level=3 | Sets dcgmi run-level to 3 |
 |  | --mem-level | 0 (default) or 1 | Memory diagnostics run-level | --mem-level=1 | Enables stream benchmark test |
 
 ## Tarball Structure


### PR DESCRIPTION
- sets default run level to 1
- adds timeouts
- only runs requested run-level instead of all ones up to that level

This PR is in response to three pieces of information:

- Advice from PerfInsights team to minimize the potential impact of the default configuration for the tool
- While running on VMs with faulty GPUs, DCGM Diag can get stuck #11 
- Nvidia docs indicate that lower run-levels of DCGM Diag are essentially subsets of higher ones

