### PR TITLE
don't run checks on gpus without nvidia-smi installed

### DIFF
--- a/Linux/test/mocks.bash
+++ b/Linux/test/mocks.bash
@@ -81,3 +81,24 @@ function lspci {
         fi
     done
 }
+
+function hide_command {
+    local command="$1"
+    local command_path command_dir tmpdir command_type
+    while command_type=$(type -t "$command"); do
+        case "$command_type" in
+            alias) unalias "$command";;
+            function) unset -f "$command";;
+            file)
+                command_path=$(command -v "$command")
+                command_dir=$(dirname "$command_path")
+                tmpdir=$(mktemp -d)
+                cp -r "$command_dir"/* "$tmpdir"
+                rm "$tmpdir/$command"
+
+                PATH="$(echo "$PATH" | sed "s:\(^\|\:\)$command_dir\(\:\|$\):\1$tmpdir\2:g")"
+                ;;
+            *) echo "cannot remove command of type $command_type"; return 1;;
+        esac
+    done
+}

--- a/Linux/test/nvidia-smi.bats
+++ b/Linux/test/nvidia-smi.bats
@@ -68,6 +68,42 @@ function teardown {
     assert grep -q "$output" "$DIAG_DIR/transcript.log"
 }
 
+@test "page retirement - fail gracefully without nvidia-smi" {
+    . "$BATS_TEST_DIRNAME/mocks.bash"
+    hide_command nvidia-smi
+
+    run check_page_retirement
+    assert_failure
+    refute_output --partial "BAD GPU"
+}
+
+@test "missing gpus - fail gracefully without nvidia-smi" {
+    . "$BATS_TEST_DIRNAME/mocks.bash"
+    hide_command nvidia-smi
+
+    run check_missing_gpus
+    assert_failure
+    refute_output --partial "BAD GPU"
+}
+
+@test "inforom - fail gracefully without nvidia-smi" {
+    . "$BATS_TEST_DIRNAME/mocks.bash"
+    hide_command nvidia-smi
+
+    run check_inforom
+    assert_failure
+    refute_output --partial "BAD GPU"
+}
+
+@test "report_bad_gpu - fail gracefully without nvidia-smi" {
+    . "$BATS_TEST_DIRNAME/mocks.bash"
+    hide_command nvidia-smi
+
+    run report_bad_gpu --index=2 --reason=reason
+    assert_failure
+    refute_output --partial "BAD GPU"
+}
+
 @test "detect dbe over threshold" {
     . "$BATS_TEST_DIRNAME/mocks.bash"
 


### PR DESCRIPTION
This fixes a false positive in the following scenario:

If we're running on a GPU instance without the Nvidia drivers installed, we get no output from nvidia-smi, and when we compare that to what we get from lspci, we conclude that the GPUs are failing to come up in nvidia-smi.

Instead, these checks for common issues (gpu-related) should not be run when nvidia-smi, which they all depend on, is not present.