### PR TITLE
Fixes for pkey collection and adding related tests

### DIFF
--- a/Linux/src/gather_azhpc_vm_diagnostics.sh
+++ b/Linux/src/gather_azhpc_vm_diagnostics.sh
@@ -389,10 +389,14 @@ run_infiniband_diags() {
 
         local pkey_count
         pkey_count=$(find "$dir/" -path '*pkeys/*' -execdir echo {} \; | wc -l)
-        print_log -e "\tFound $pkey_count pkeys in $dir; copying them to {output}/Infiniband/$device/pkeys/"
-
-        find "$dir/" -path '*pkeys/*' \
-            -execdir cp {} "$DIAG_DIR/Infiniband/$device/pkeys" \;
+        if [ "$pkey_count" -gt 0 ]; then
+            mkdir -p "$DIAG_DIR/Infiniband"
+            print_log -e "\tFound $pkey_count pkeys in $dir; copying them to {output}/Infiniband/$device/pkeys/"
+            find "$dir/" -path '*pkeys/*' \
+                -execdir cp {} "$DIAG_DIR/Infiniband/$device/pkeys" \;
+        else
+            print_log -e "\tFound no pkeys in $dir"
+        fi
     done
 }
 

--- a/Linux/src/gather_azhpc_vm_diagnostics.sh
+++ b/Linux/src/gather_azhpc_vm_diagnostics.sh
@@ -54,7 +54,7 @@ STREAM_URL='https://azhpcstor.blob.core.windows.net/diagtool-binaries/stream.tgz
 LSVMBUS_URL='https://raw.githubusercontent.com/torvalds/linux/master/tools/hv/lsvmbus'
 HPC_DIAG_URL='https://raw.githubusercontent.com/Azure/azhpc-diagnostics/main/Linux/src/gather_azhpc_vm_diagnostics.sh'
 SCRIPT_DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
-DEVICES_PATH="/sys/bus/vmbus/devices" # store as a variable so it is mockable
+SYSFS_PATH=/sys # store as a variable so it is mockable
 
 # Mapping for stream benchmark(AMD only)
 declare -A CPU_LIST
@@ -379,7 +379,7 @@ run_infiniband_diags() {
     fi
 
     print_log -e "\tChecking for Infiniband pkeys"
-    for dir in /sys/class/infiniband/*; do
+    for dir in "$SYSFS_PATH"/class/infiniband/*; do
         [ -d "$dir" ] || continue
 
         print_log -e "\tChecking for Infiniband pkeys in $dir"
@@ -552,6 +552,7 @@ function report_bad_gpu {
     fi
 
     local device
+    local DEVICES_PATH="$SYSFS_PATH/bus/vmbus/devices"
     device=$(find -L "$DEVICES_PATH" -maxdepth 2 -mindepth 2 -iname "*${pci_domain#0x}*")
     local bus_id
     bus_id=$(basename "$(dirname "$device")")

--- a/Linux/test/compatibility.bats
+++ b/Linux/test/compatibility.bats
@@ -111,5 +111,8 @@ function setup() {
         Standard_N*) skip "unknown gpu size $VM_SIZE";;
         *) GPU_COUNT=0;;
     esac
+    if ! lspci >/dev/null 2>/dev/null; then
+        skip "no functioning installation of lspci"
+    fi
     assert_equal $(lspci -d "$NVIDIA_PCI_ID:" | wc -l) $GPU_COUNT
 }

--- a/Linux/test/compatibility.bats
+++ b/Linux/test/compatibility.bats
@@ -116,3 +116,19 @@ function setup() {
     fi
     assert_equal $(lspci -d "$NVIDIA_PCI_ID:" | wc -l) $GPU_COUNT
 }
+
+@test "Confirm that pkeys are where we think" {
+    if ! [ -d /sys/class/infiniband ]; then
+        skip "no infiniband section of sysfs"
+    fi
+    if [ $(ls /sys/class/infiniband | wc -l) -eq 0 ]; then
+        skip "no devices appear in infiniband section of sysfs"
+    fi
+
+    local pkey_count
+    for dir in /sys/class/infiniband/*; do
+        [ -d "$dir" ] || continue
+        pkey_count=$(find "$dir/" -path '*pkeys/*' -execdir echo {} \; | wc -l)
+        assert [ $pkey_count -gt 0 ]
+    done
+}

--- a/Linux/test/compatibility.bats
+++ b/Linux/test/compatibility.bats
@@ -3,7 +3,7 @@
 # i.e. fail if a tool's output has changed to be incompatible with our parsing
 
 NVIDIA_PCI_ID=10de
-SYSLOG_MESSAGE_PATTERN='^[A-Z][a-z]{2} [0-9]{1,2} [0-9]{2}:[0-9]{2}:[0-9]{2} [^ ]+ [^:]+:'
+SYSLOG_MESSAGE_PATTERN='^[A-Z][a-z]{2} [ 0123][0-9] [0-9]{2}:[0-9]{2}:[0-9]{2} [^ ]+ [^:]+:'
 
 function setup() {
     load "test_helper/bats-support/load"

--- a/Linux/test/infiniband.bats
+++ b/Linux/test/infiniband.bats
@@ -1,0 +1,118 @@
+#!/bin/usr/env bats
+# Tests for infiniband diagnostic collection
+
+function setup {
+    load "test_helper/bats-support/load"
+    load "test_helper/bats-assert/load"
+    load ../src/gather_azhpc_vm_diagnostics.sh --no-update
+
+    DIAG_DIR=$(mktemp -d)
+    mkdir -p "$DIAG_DIR"
+
+    SYSFS_PATH=$(mktemp -d)
+    
+    local IB_DEVICES_PATH="$SYSFS_PATH/class/infiniband"
+    mkdir -p "$IB_DEVICES_PATH/mlx4_0/ports/1/pkeys"
+    echo 0xffff > "$IB_DEVICES_PATH/mlx4_0/ports/1/pkeys/0"
+    echo 0x0001 > "$IB_DEVICES_PATH/mlx4_0/ports/1/pkeys/1"
+    mkdir -p "$IB_DEVICES_PATH/mlx5_1/ports/1/pkeys"
+    echo 0xffff > "$IB_DEVICES_PATH/mlx5_1/ports/1/pkeys/0"
+    echo 0x0001 > "$IB_DEVICES_PATH/mlx5_1/ports/1/pkeys/1"
+}
+
+function teardown {
+    rm -rf "$DIAG_DIR" "$SYSFS_PATH"
+}
+
+@test "Confirm that pkeys get collected" {
+    run run_infiniband_diags
+    assert_success
+
+    run cat "$DIAG_DIR/Infiniband/mlx4_0/pkeys/0"
+    assert_success
+    assert_output 0xffff
+
+    run cat "$DIAG_DIR/Infiniband/mlx4_0/pkeys/1"
+    assert_success
+    assert_output 0x0001
+}
+
+@test "Confirm that ib tools get run" {
+    . "$BATS_TEST_DIRNAME/mocks.bash"
+
+    run run_infiniband_diags
+    assert_success
+
+    run cat "$DIAG_DIR/Infiniband/ibstat.txt"
+    assert_success
+    assert_output
+
+    run cat "$DIAG_DIR/Infiniband/ibv_devinfo.txt"
+    assert_success
+    assert_output "full output"
+}
+
+@test "Confirm that lack of ibstat is noticed" {
+    . "$BATS_TEST_DIRNAME/mocks.bash"
+
+    hide_command ibstat
+
+    run run_infiniband_diags
+    assert_success
+
+    assert_output --partial "No Infiniband Driver Detected"
+
+    refute [ -f "$DIAG_DIR/Infiniband/ibstat.txt" ]
+    refute [ -f "$DIAG_DIR/Infiniband/ibv_devinfo.txt" ]
+}
+
+@test "Confirm that ib-vmext-status gets collected" {
+    local dir_exists
+    if [ -d /var/log/azure ]; then
+        dir_exists=true
+    else
+        dir_exists=false
+        mkdir -p /var/log/azure
+    fi
+    local file_exists
+    if [ -f /var/log/azure/ib-vmext-status ]; then
+        file_exists=true
+    else
+        file_exists=false
+        touch /var/log/azure/ib-vmext-status
+    fi
+
+    run run_infiniband_diags
+    assert_success
+
+    assert [ -f "$DIAG_DIR/Infiniband/ib-vmext-status" ]
+
+    if [ "$file_exists" == false ]; then
+        rm /var/log/azure/ib-vmext-status
+    fi
+    if [ "$dir_exists" == false ]; then
+        rm -r /var/log/azure
+    fi
+}
+
+@test "Confirm that lack of pkeys is noticed" {
+    . "$BATS_TEST_DIRNAME/mocks.bash"
+    run_infiniband_diags
+
+    run check_pkeys
+    refute_output
+
+    rm "$DIAG_DIR/Infiniband/mlx4_0/pkeys/0"
+    run check_pkeys
+    assert_output --partial "Could not find pkey 0 for device mlx4_0"
+    refute_output --partial "Could not find pkey 1 for device mlx4_0"
+    refute_output --partial "Could not find pkey 0 for device mlx5_1"
+    refute_output --partial "Could not find pkey 1 for device mlx5_1"
+
+    rm "$DIAG_DIR/Infiniband/mlx5_1/pkeys/1"
+    run check_pkeys
+    assert_output --partial "Could not find pkey 0 for device mlx4_0"
+    refute_output --partial "Could not find pkey 1 for device mlx4_0"
+    refute_output --partial "Could not find pkey 0 for device mlx5_1"
+    assert_output --partial "Could not find pkey 1 for device mlx5_1"
+}

--- a/Linux/test/mocks.bash
+++ b/Linux/test/mocks.bash
@@ -82,6 +82,18 @@ function lspci {
     done
 }
 
+function ibstat {
+    echo "infiniband results"
+}
+
+function ibv_devinfo {
+    if [ "$1" == "-v" ]; then
+        echo "full output"
+    else
+        echo "less output"
+    fi
+}
+
 function hide_command {
     local command="$1"
     local command_path command_dir tmpdir command_type

--- a/Linux/test/nvidia-smi.bats
+++ b/Linux/test/nvidia-smi.bats
@@ -10,17 +10,16 @@ function setup {
     mkdir -p "$DIAG_DIR/Nvidia"
     cp "$BATS_TEST_DIRNAME/samples/nvidia-smi-q.out" "$DIAG_DIR/Nvidia/nvidia-smi-q.out"
     grep -v 'infoROM is corrupted' "$BATS_TEST_DIRNAME/samples/nvidia-smi-inforom.out" >"$DIAG_DIR/Nvidia/nvidia-smi.out"
-
-    SAVED_DEVICES_PATH="$DEVICES_PATH"
-    DEVICES_PATH=$(mktemp -d)
+    
+    SYSFS_PATH=$(mktemp -d)
+    local DEVICES_PATH="$SYSFS_PATH/bus/vmbus/devices"
     for i in {1..4}; do
         mkdir -p "$DEVICES_PATH/00000000-0000-0000-0000-00000000000$i/pci000$i:00"
     done
 }
 
 function teardown {
-    rm -rf "$DIAG_DIR" "$DEVICES_PATH"
-    DEVICES_PATH="$SAVED_DEVICES_PATH"
+    rm -rf "$DIAG_DIR" "$SYSFS_PATH"
 }
 
 @test "no dbe violations" {

--- a/Linux/test/run_tests.sh
+++ b/Linux/test/run_tests.sh
@@ -47,15 +47,6 @@ Memory/stream.txt"
 INFINIBAND_FILENAMES="Infiniband/ibstat.txt
 Infiniband/ibv_devinfo.txt"
 
-pkey_filenames() {
-    local devices="$1"
-    for device in $(echo "$devices" | tr ',' '\n'); do
-    echo "Infiniband/$device/
-Infiniband/$device/pkeys/
-Infiniband/$device/pkeys/0"
-    done
-}
-
 INFINIBAND_EXT_FILENAMES="Infiniband/ib-vmext-status"
 
 INFINIBAND_FOLDER="Infiniband/"
@@ -126,7 +117,7 @@ sudo_basic_script_test() {
     for filename in $filenames; do
         if [[ "$filename" =~ ^Nvidia/stats_.*$ ]] ||
            [[ "$filename" =~ ^Nvidia/nvvs.log$ ]] ||
-           [[ "$filename" =~ ^Infiniband/.*/pkeys/.* ]]; then
+           [[ "$filename" =~ ^Infiniband/.* ]]; then
             continue # leave behavior for these undefined
         fi
 
@@ -149,7 +140,7 @@ sudo_basic_script_test() {
 
 
 # Read in options
-options_list='pkeys:,infiniband,ib-ext,nvidia,nvidia-ext,dcgm,stream'
+options_list='infiniband,ib-ext,nvidia,nvidia-ext,dcgm,stream'
 if ! PARSED_OPTIONS=$(getopt -n "$0" -o '' --long "$options_list"  -- "$@"); then
         echo "$HELP_MESSAGE"
         exit 1
@@ -159,10 +150,6 @@ eval set -- "$PARSED_OPTIONS"
 while [ "$1" != "--" ]; do
   case "$1" in
     --infiniband) INFINIBAND_PRESENT=true;;
-    --pkeys) 
-        shift
-        IB_DEVICE_LIST="$1"
-        ;;
     --ib-ext) INFINIBAND_EXT_PRESENT=true;;
     --nvidia) NVIDIA_PRESENT=true;;
     --nvidia-ext) NVIDIA_EXT_PRESENT=true;;
@@ -175,10 +162,6 @@ shift
 
 if [ "$INFINIBAND_PRESENT" = true ];then
     BASE_FILENAMES=$(cat <(echo "$BASE_FILENAMES") <(echo "$INFINIBAND_FILENAMES"))
-fi
-
-if [ -n "$IB_DEVICE_LIST" ]; then
-    BASE_FILENAMES=$(cat <(echo "$BASE_FILENAMES") <(pkey_filenames "$IB_DEVICE_LIST"))
 fi
 
 if [ "$INFINIBAND_EXT_PRESENT" = true ];then


### PR DESCRIPTION
This fixes two issues related to pkey checks:

- Fixes a bug that causes errors in checking for the existence of pkeys on multi-IB systems.
- Fixes pkey collection when no IB driver is installed

It also improves the testing/mocking infrastructure to test these IB-related checks more thoroughly and as part of the BATS tests.

Also includes a quick fix to a regex that's part of a compatibility checks for syslog formats as well as graceful handling of running tests on VMs with non-functioning lspci installations.