### PR TITLE
A100 -- PCI Bandwidth and Row Remapping

### DIFF
--- a/Linux/src/gather_azhpc_vm_diagnostics.sh
+++ b/Linux/src/gather_azhpc_vm_diagnostics.sh
@@ -53,6 +53,9 @@ HPC_DIAG_URL='https://raw.githubusercontent.com/Azure/azhpc-diagnostics/main/Lin
 SCRIPT_DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
 SYSFS_PATH=/sys # store as a variable so it is mockable
 
+NVIDIA_PCI_ID=10de
+GPU_PCI_CLASS_ID=0302
+
 # Mapping for stream benchmark(AMD only)
 declare -A CPU_LIST
 CPU_LIST=(["Standard_HB120rs_v2"]="0 1,5,9,13,17,21,25,29,33,37,41,45,49,53,57,61,65,69,73,77,81,85,89,93,97,101,105,109,113,117"
@@ -523,10 +526,10 @@ function report_bad_gpu {
     fi
     
     eval set -- "$PARSED_OPTIONS"
-    local i reason pci_domain
+    local index reason pci_domain
     while [ "$1" != "--" ]; do
         case "$1" in
-            -i|--index) i=$2;;
+            -i|--index) index=$2;;
             --reason) reason=$2;;
             --pci-domain) pci_domain=$2;;
         esac
@@ -534,23 +537,24 @@ function report_bad_gpu {
     done
     shift
 
-    local serial
-    if [ -n "$i" ]; then
-        if [ -z "$pci_domain" ]; then
-            pci_domain=$(nvidia-smi --query-gpu=pci.domain -i "$i" --format=csv,noheader) || {
-                print_log -e "\treport_bad_gpu called, but nvidia-smi is failing"
-                return 1
-            }
-        else
-            failwith "both gpu index and pci domain passed into report_bad_gpu"
+    if [ -n "$index" ] && [ -n "$pci_domain" ]; then
+        if [ "$pci_domain" != "$(nvidia-smi --query-gpu=pci.domain -i "$index" --format=csv,noheader)" ]; then
+            print_log -e "\tmismatched gpu index and pci domain passed in"
+            return 1
         fi
-        serial=$(nvidia-smi --query-gpu=serial -i "$i" --format=csv,noheader) || {
-            print_log -e "\treport_bad_gpu called, but nvidia-smi is failing"
+    elif [ -n "$index" ]; then
+        pci_domain=$(nvidia-smi --query-gpu=pci.domain -i "$index" --format=csv,noheader) || {
+            print_log -e "nvidia-smi failed during bad gpu reporting"
             return 1
         }
-    else
-        serial=UNKNOWN
+    elif [ -n "$pci_domain" ]; then
+        index=$(nvidia-smi --query-gpu=pci.domain,index --format=csv,noheader 2>/dev/null | grep -i "^0x$pci_domain" | cut -d' ' -f 2)
     fi
+
+    local serial
+    [ -n "$index" ] &&
+        serial=$(nvidia-smi --query-gpu=serial -i "$index" --format=csv,noheader) || 
+        serial=UNKNOWN
 
     local device
     local DEVICES_PATH="$SYSFS_PATH/bus/vmbus/devices"
@@ -619,6 +623,20 @@ function check_nouveau {
     if grep -q nouveau "$DIAG_DIR/VM/lsmod.txt"; then
         print_log -e '\tNouveau driver detected. This driver is unsupported.'
     fi
+}
+
+function check_pci_bandwidth {
+    for pci_id in $(lspci -d "$NVIDIA_PCI_ID:" -mnD | awk '$2 == "\"'"$GPU_PCI_CLASS_ID"'\"" {print $1}'); do
+        local speed_cap width_cap speed_sta width_sta
+        speed_cap=$(lspci -vv -s "$pci_id" | grep 'LnkCap:' | grep -o 'Speed [0-9.]\+GT/s' | grep -o '[0-9.]\+')
+        speed_sta=$(lspci -vv -s "$pci_id" | grep 'LnkSta:' | grep -o 'Speed [0-9.]\+GT/s' | grep -o '[0-9.]\+')
+        width_cap=$(lspci -vv -s "$pci_id" | grep 'LnkCap:' | grep -o 'Width x[0-9]\+' | grep -o '[0-9]\+')
+        width_sta=$(lspci -vv -s "$pci_id" | grep 'LnkSta:' | grep -o 'Width x[0-9]\+' | grep -o '[0-9]\+')
+        if [ "$speed_sta" -ne "$speed_cap" ] || [ "$width_sta" -ne "$width_cap" ]; then
+            local reason="PCIe link not showing expected performance: OBSERVED Speed ${speed_sta}GT/s, Width x${width_sta}; EXPECTED ${speed_cap}GT/s, Width x${width_cap}"
+            report_bad_gpu --pci-domain="$(echo "$pci_id" | cut -d: -f1)" --reason="$reason"
+        fi
+    done
 }
 
 function check_pkeys {
@@ -783,6 +801,7 @@ function main {
         check_inforom
         check_page_retirement
         check_missing_gpus
+        check_pci_bandwidth
         if is_nvidia_compute_sku "$VM_SIZE"; then
             check_nouveau
         fi

--- a/Linux/src/gather_azhpc_vm_diagnostics.sh
+++ b/Linux/src/gather_azhpc_vm_diagnostics.sh
@@ -575,21 +575,36 @@ function report_bad_gpu {
 }
 
 function check_page_retirement {
-    local i=0
-    local query_output
-    query_output=$(nvidia-smi --query-gpu=retired_pages.sbe,retired_pages.dbe --format=csv,noheader) || {
+    local remapped_rows sbe_dbe pci_domain
+    remapped_rows=$(nvidia-smi --query-remapped-rows=remapped_rows.failure,gpu_bus_id --format=csv,noheader) || {
         print_log -e "\tcheck_page_retirement called, but nvidia-smi is failing"
         return 1
     }
-    print_log -e "\tChecking for GPUs over the page retirement threshold"
-    echo "$query_output" | sed 's/, /\t/g' |
-    while read -r sbe dbe; do 
-        local retired_page_count=$(( sbe + dbe ))
-        if (( retired_page_count >= 60 )); then
-            report_bad_gpu --index="$i" --reason="DBE($retired_page_count)"
-        fi
-        ((i++))
-    done
+    sbe_dbe=$(nvidia-smi --query-gpu=retired_pages.sbe,retired_pages.dbe, --format=csv,noheader) || {
+        print_log -e "\tcheck_page_retirement called, but nvidia-smi is failing"
+        return 1
+    }
+    if echo "$remapped_rows" | grep -Eiq '\[N/A\]'; then
+        print_log -e "\tChecking for GPUs over the page retirement threshold"
+        local i=0
+        echo "$sbe_dbe" | sed 's/, /\t/g' |
+        while read -r sbe dbe; do 
+            local retired_page_count=$(( sbe + dbe ))
+            if (( retired_page_count >= 60 )); then
+                report_bad_gpu --index="$i" --reason="DBE($retired_page_count)"
+            fi
+            ((i++))
+        done
+    else
+        print_log -e "\tChecking for GPUs with row remapping failures"
+        echo "$remapped_rows" | sed 's/, /\t/g' |
+        while read -r row_remap_failure pci_bus_id; do
+            if (( row_remap_failure == 1 )); then
+                pci_domain=$(echo "$pci_bus_id" | cut -d: -f1 | sed -E 's/^.{4}//g')
+                report_bad_gpu --pci-domain="$pci_domain" --reason="Row Remap Failure"
+            fi
+        done
+    fi
 }
 
 function check_inforom {

--- a/Linux/src/gather_azhpc_vm_diagnostics.sh
+++ b/Linux/src/gather_azhpc_vm_diagnostics.sh
@@ -599,14 +599,13 @@ function check_inforom {
 }
 
 function check_missing_gpus {
-    local NVIDIA_PCI_ID=10de
     local pci_domains nvsmi_domains
     nvsmi_domains=$(mktemp)
     nvidia-smi --query-gpu=pci.domain --format=csv,noheader >"$nvsmi_domains" || {
         print_log -e "\tcheck_missing_gpus called, but nvidia-smi is failing"
         return 1
     }
-    pci_domains=$(lspci -d "$NVIDIA_PCI_ID:" -mD | cut -d: -f1)
+    pci_domains=$(lspci -d "$NVIDIA_PCI_ID:" -mnD | grep -E "\S+\s\"$GPU_PCI_CLASS_ID\"" | cut -d: -f1)
     print_log -e "\tChecking for GPUs that don't appear in nvidia-smi"
     for pci_domain in $pci_domains; do
         if ! grep -iq "^0x$pci_domain$" "$nvsmi_domains"; then

--- a/Linux/src/gather_azhpc_vm_diagnostics.sh
+++ b/Linux/src/gather_azhpc_vm_diagnostics.sh
@@ -706,20 +706,18 @@ function check_pci_bandwidth {
     done
 }
 
-function expected_cuda_bandwidth {
+function threshold_cuda_bandwidth {
     local vm_size="$1"
     case "$vm_size" in
-        Standard_ND96asr_v4) echo -n 32;;
+        Standard_ND96asr_v4) echo -n 20;;
         *) return 1;; # size not supported for gpu-numa tests
     esac
 }
 
 function check_cuda_bandwidth {
     local vm_size="$1"
-    local expected_bw tolerance_factor threshold
-    expected_bw=$(expected_cuda_bandwidth "$vm_size")
-    tolerance_factor=0.8
-    threshold=$(float_op "$expected_bw" '*' "$tolerance_factor")
+    local threshold
+    threshold=$(threshold_cuda_bandwidth "$vm_size")
 
     print_log -e "\tChecking for GPUs with low bandwidth"
     for results in "$DIAG_DIR"/Nvidia/bandwidthTest/*.csv; do

--- a/Linux/test/compatibility.bats
+++ b/Linux/test/compatibility.bats
@@ -12,9 +12,12 @@ function setup() {
     load "test_helper/bats-assert/load"
 }
 
-@test "Confirm that nvidia-smi dbe query is still compatible" {
+@test "Confirm that nvidia-smi sbe/dbe query is still compatible" {
     if ! nvidia-smi >/dev/null; then
         skip "nvidia-smi not installed"
+    fi
+    if nvidia-smi --query-gpu=retired_pages.sbe,retired_pages.dbe --format=csv,noheader | grep -Eiq '[N/A]'; then
+        skip "GPU doesn't report retired pages"
     fi
     run nvidia-smi --query-gpu=retired_pages.sbe,retired_pages.dbe --format=csv,noheader
 
@@ -23,6 +26,33 @@ function setup() {
     for i in "${!lines[@]}"; do
         assert_line --index $i --regexp '^[0-9]+, [0-9]+$'
     done
+}
+
+@test "Confirm that nvidia-smi remapped rows query is still compatible" {
+    if ! nvidia-smi >/dev/null; then
+        skip "nvidia-smi not installed"
+    fi
+    if nvidia-smi --query-remapped-rows=remapped_rows.failure,gpu_bus_id --format=csv,noheader | grep -Eiq '[N/A]'; then
+        skip "GPU doesn't report remapped rows"
+    fi
+    run nvidia-smi --query-remapped-rows=remapped_rows.failure,gpu_bus_id --format=csv,noheader
+
+    for i in "${!lines[@]}"; do
+        assert_line --index $i --regexp '^[01], [0-9a-fA-F]{8}:.*$'
+    done
+}
+
+@test "Confirm that GPU supports retired pages XOR remapped rows" {
+    if ! nvidia-smi >/dev/null; then
+        skip "nvidia-smi not installed"
+    fi
+    
+    run nvidia-smi --query-gpu=retired_pages.sbe,retired_pages.dbe --format=csv,noheader
+    if nvidia-smi --query-remapped-rows=remapped_rows.failure --format=csv,noheader | grep -Eiq '[N/A]'; then
+        refute_output --partial '[N/A]'
+    else
+        assert_output --partial '[N/A]'
+    fi
 }
 
 @test "Confirm that nvidia-smi pci.domain query is still compatible" {

--- a/Linux/test/compatibility.bats
+++ b/Linux/test/compatibility.bats
@@ -86,6 +86,9 @@ function setup() {
 }
 
 @test "Confirm that lspci prints one non-indented line per device" {
+    if ! lspci >/dev/null 2>/dev/null; then
+        skip "no functioning installation of lspci"
+    fi
     if [ $(lspci | wc -l) -eq 0 ]; then
         skip "no pci devices present"
     fi
@@ -116,6 +119,22 @@ function setup() {
         skip "no functioning installation of lspci"
     fi
     assert_equal $(lspci -d "$NVIDIA_PCI_ID:" -mnD | awk '$2 == "\"'"$GPU_PCI_CLASS_ID"'\"" {print $1}' | wc -l) $GPU_COUNT
+}
+
+@test "Confirm that GPU bandwidth fields from lspci are formatted as expected" {
+    if ! lspci >/dev/null 2>/dev/null; then
+        skip "no functioning installation of lspci"
+    fi
+    local GPUs
+    GPUs=$(lspci -d "$NVIDIA_PCI_ID:" -mnD | awk '$2 == "\"'"$GPU_PCI_CLASS_ID"'\"" {print $1}')
+    if [ -z "$GPUs" ]; then
+        skip "No GPUs found with lspci"
+    fi
+    for gpu in $GPUs; do
+        run lspci -vv -s $gpu
+        assert_output --regexp 'LnkCap:\s+.*Speed [0-9.]+GT/s.*Width x[0-9]+'
+        assert_output --regexp 'LnkSta:\s+.*Speed [0-9.]+GT/s.*Width x[0-9]+'
+    done
 }
 
 @test "Confirm that pkeys are where we think" {

--- a/Linux/test/compatibility.bats
+++ b/Linux/test/compatibility.bats
@@ -3,6 +3,7 @@
 # i.e. fail if a tool's output has changed to be incompatible with our parsing
 
 NVIDIA_PCI_ID=10de
+GPU_PCI_CLASS_ID=0302
 SYSLOG_MESSAGE_PATTERN='^[A-Z][a-z]{2} [ 0123][0-9] [0-9]{2}:[0-9]{2}:[0-9]{2} [^ ]+ [^:]+:'
 
 function setup() {
@@ -114,7 +115,7 @@ function setup() {
     if ! lspci >/dev/null 2>/dev/null; then
         skip "no functioning installation of lspci"
     fi
-    assert_equal $(lspci -d "$NVIDIA_PCI_ID:" | wc -l) $GPU_COUNT
+    assert_equal $(lspci -d "$NVIDIA_PCI_ID:" -mnD | awk '$2 == "\"'"$GPU_PCI_CLASS_ID"'\"" {print $1}' | wc -l) $GPU_COUNT
 }
 
 @test "Confirm that pkeys are where we think" {

--- a/Linux/test/lspci.bats
+++ b/Linux/test/lspci.bats
@@ -1,0 +1,61 @@
+#!/bin/usr/env bats
+# testing analysis of lspci outputs
+
+function setup {
+    load "test_helper/bats-support/load"
+    load "test_helper/bats-assert/load"
+    load ../src/gather_azhpc_vm_diagnostics.sh --no-update
+
+    DIAG_DIR=$(mktemp -d)
+    mkdir -p "$DIAG_DIR/Nvidia"
+    cp "$BATS_TEST_DIRNAME/samples/nvidia-smi-q.out" "$DIAG_DIR/Nvidia/nvidia-smi-q.out"
+    grep -v 'infoROM is corrupted' "$BATS_TEST_DIRNAME/samples/nvidia-smi-inforom.out" >"$DIAG_DIR/Nvidia/nvidia-smi.out"
+
+    SAVED_DEVICES_PATH="$DEVICES_PATH"
+    DEVICES_PATH=$(mktemp -d)
+    for i in 1 2 a d; do
+        mkdir -p "$DEVICES_PATH/00000000-0000-0000-0000-00000000000$i/pci000$i:00"
+    done
+}
+
+@test "lspci bandwidth - fail gracefully without nvidia-smi" {
+    . "$BATS_TEST_DIRNAME/mocks.bash"
+    hide_command nvidia-smi
+    MOCK_LNKSTA[0]="\tLnkSta: Port #1, Speed 8GT/s, Width x16"
+
+    run check_pci_bandwidth
+    assert_success
+    assert_output --partial "BAD GPU"
+    assert_output --partial "PCIe link not showing expected performance"
+    assert_output --partial "UNKNOWN"
+}
+
+@test "check_pci_bandwidth" {
+    . "$BATS_TEST_DIRNAME/mocks.bash"
+
+    run check_pci_bandwidth
+    assert_success
+    refute_output
+}
+
+@test "lspci bandwidth (low speed) - get serial with nvidia-smi" {
+    . "$BATS_TEST_DIRNAME/mocks.bash"
+    MOCK_LNKSTA[0]="\tLnkSta: Port #1, Speed 8GT/s, Width x16"
+
+    run check_pci_bandwidth
+    assert_success
+    assert_output --partial "BAD GPU"
+    assert_output --partial "PCIe link not showing expected performance"
+    refute_output --partial "UNKNOWN"
+}
+
+@test "lspci bandwidth (low width) - get serial with nvidia-smi" {
+    . "$BATS_TEST_DIRNAME/mocks.bash"
+    MOCK_LNKSTA[0]="\tLnkSta: Port #1, Speed 16GT/s, Width x8"
+
+    run check_pci_bandwidth
+    assert_success
+    assert_output --partial "BAD GPU"
+    assert_output --partial "PCIe link not showing expected performance"
+    refute_output --partial "UNKNOWN"
+}

--- a/Linux/test/mock_data/nvidia-smi-query-gpu.csv
+++ b/Linux/test/mock_data/nvidia-smi-query-gpu.csv
@@ -1,0 +1,5 @@
+index,serial,pci.domain,retired_pages.dbe,retired_pages.sbe,remapped_rows.failure,gpu_bus_id
+0,0000000000001,0x0001,0,0,[N/A],00000001:00:00.0
+1,0000000000002,0x0002,0,0,[N/A],00000002:00:00.0
+2,0000000000003,0x000A,0,0,[N/A],0000000A:00:00.0
+3,0000000000004,0x000D,0,0,[N/A],0000000D:00:00.0

--- a/Linux/test/mocks.bash
+++ b/Linux/test/mocks.bash
@@ -60,13 +60,21 @@ function journalctl {
 }
 
 declare -a MOCK_PCI_DEVICES
-MOCK_PCI_DEVICES=( "0001:00:00.0 NVIDIA" "0002:00:00.0 NVIDIA" "000a:00:00.0 NVIDIA" "000d:00:00.0 NVIDIA" "0005:00:00.0 MELLANOX" )
+MOCK_PCI_DEVICES=( 
+    '0001:00:00.0 "0302" "10de" "1db5" -ra1 "10de" "1249"'
+    '0002:00:00.0 "0302" "10de" "1db5" -ra1 "10de" "1249"'
+    '000a:00:00.0 "0302" "10de" "1db5" -ra1 "10de" "1249"'
+    '000d:00:00.0 "0302" "10de" "1db5" -ra1 "10de" "1249"'
+    '1421:00:02.0 "0207" "15b3" "1018" "15b3" "0003"'
+)
 function lspci {
-    if ! PARSED_OPTIONS=$(getopt -n "$0" -o d:mD -- "$@"); then
+    if ! PARSED_OPTIONS=$(getopt -n "$0" -o d:mns:vD -- "$@"); then
         return 1
     fi
     eval set -- "$PARSED_OPTIONS"
-    local vendor # machine_readable show_domain
+    local vendor='[0-9a-f]{4}' # default to wildcard
+    local bus_id='[0-9a-f]{4}:[0-9a-f]{2}:[01][0-9a-f].[0-7]' # default to wildcard
+
     while [ "$1" != "--" ]; do
         case "$1" in
             -d) shift; vendor="$1";;
@@ -75,8 +83,9 @@ function lspci {
         esac
         shift
     done
-    for device in "${MOCK_PCI_DEVICES[@]}"; do 
-        if echo "$device" | grep -q NVIDIA || [ "$vendor" != 10de: ]; then
+    for i in "${!MOCK_PCI_DEVICES[@]}"; do
+        local device=${MOCK_PCI_DEVICES[$i]}
+        if [[ "$device" =~ ^${bus_id}\ \"[0-9a-f]{4}\"\ \"${vendor}\" ]]; then
             echo "$device"
         fi
     done

--- a/Linux/test/mocks.bash
+++ b/Linux/test/mocks.bash
@@ -1,33 +1,26 @@
 #!/bin/bash
 # mocks of 3rd party tools
 
-declare -a MOCK_GPU_SBE_DBE_COUNTS
-MOCK_GPU_SBE_DBE_COUNTS=( "0, 0" "0, 0" "0, 0" "0, 0" )
-
-declare -a MOCK_GPU_PCI_DOMAINS
-MOCK_GPU_PCI_DOMAINS=( 0x0001 0x0002 0x000A 0x000D )
-
-declare -a MOCK_GPU_PCI_DOMAIN_INDEX
-MOCK_GPU_PCI_DOMAIN_INDEX=( "0x0001, 0" "0x0002, 1" "0x000A, 2" "0x000D, 3" )
-
-declare -a MOCK_GPU_PCI_INDEX
-MOCK_GPU_PCI_INDEX=( 0 1 2 3 )
-
-declare -a MOCK_GPU_PCI_SERIALS
-MOCK_GPU_PCI_SERIALS=( 0000000000001 0000000000002 0000000000003 0000000000004 )
+NVIDIA_SMI_QUERY_GPU_DATA=$(mktemp)
+cp "$BATS_TEST_DIRNAME/mock_data/nvidia-smi-query-gpu.csv" "$NVIDIA_SMI_QUERY_GPU_DATA"
 
 function nvidia-smi {
-    if ! PARSED_OPTIONS=$(getopt -n "$0" -o i: --long 'query-gpu:,format:' -- "$@"); then
+    if ! PARSED_OPTIONS=$(getopt -n "$0" -o i: --long 'query-gpu:,query-remapped-rows:,format:' -- "$@"); then
         echo "Invalid combination of input arguments. Please run 'nvidia-smi -h' for help."
         return 1
     fi
     eval set -- "$PARSED_OPTIONS"
-    local query i format
+    local query i format data_file
     while [ "$1" != "--" ]; do
         case "$1" in
-            --query-gpu)
+            --query-*)
+                if [ -n "$query" ]; then
+                    echo 'Only one --query-* switch can be used at a time.'
+                    return 1
+                fi
                 shift
                 query="$1"
+                data_file="$NVIDIA_SMI_QUERY_GPU_DATA"
             ;;
             -i)
                 shift
@@ -44,23 +37,29 @@ function nvidia-smi {
         echo '"--format=" switch is missing. Please run 'nvidia-smi -h' for help.'
         return 1
     fi
-    local data
-    declare -a data
-    case "$query" in
-        retired_pages.sbe,retired_pages.dbe) data=("${MOCK_GPU_SBE_DBE_COUNTS[@]}");;
-        pci.domain,index) data=("${MOCK_GPU_PCI_DOMAIN_INDEX[@]}");;
-        index) data=("${MOCK_GPU_PCI_INDEX[@]}");;
-        pci.domain) data=("${MOCK_GPU_PCI_DOMAINS[@]}");;
-        serial) data=("${MOCK_GPU_PCI_SERIALS[@]}");;
-        
-        *) echo "Field \"$query\" is not a valid field to query."; return 1;;
-    esac
-    if [ -z "$i" ]; then
-        for line in "${data[@]}"; do echo "$line"; done
-    else
-        echo "${data[$i]}"
-    fi
-    return 0
+
+    local header header_to_colnum requested_fields
+    declare -a header
+    declare -A header_to_colnum
+    declare -a requested_fields
+
+    IFS=',' read -r -a header <<< "$(head -1 "$data_file")"
+
+    local colnum=0
+    for column in "${header[@]}"; do
+        header_to_colnum[$column]=$((colnum++))
+    done
+
+    IFS=',' read -r -a requested_fields <<< "$query"
+
+    tail -n +2 "$data_file" |
+    (if [ -z "$i" ]; then cat; else awk -F, "\$$((header_to_colnum[index] + 1))==$i" ; fi) |
+    while IFS=',' read -r -a data; do
+        for field in "${requested_fields[@]}"; do
+            echo -n "${data[${header_to_colnum[$field]}]}, "
+        done
+        echo ""
+    done | sed 's/, $//g'
 }
 
 function journalctl {

--- a/Linux/test/mocks.bash
+++ b/Linux/test/mocks.bash
@@ -10,6 +10,9 @@ MOCK_GPU_PCI_DOMAINS=( 0x0001 0x0002 0x000A 0x000D )
 declare -a MOCK_GPU_PCI_DOMAIN_INDEX
 MOCK_GPU_PCI_DOMAIN_INDEX=( "0x0001, 0" "0x0002, 1" "0x000A, 2" "0x000D, 3" )
 
+declare -a MOCK_GPU_PCI_INDEX
+MOCK_GPU_PCI_INDEX=( 0 1 2 3 )
+
 declare -a MOCK_GPU_PCI_SERIALS
 MOCK_GPU_PCI_SERIALS=( 0000000000001 0000000000002 0000000000003 0000000000004 )
 
@@ -46,6 +49,7 @@ function nvidia-smi {
     case "$query" in
         retired_pages.sbe,retired_pages.dbe) data=("${MOCK_GPU_SBE_DBE_COUNTS[@]}");;
         pci.domain,index) data=("${MOCK_GPU_PCI_DOMAIN_INDEX[@]}");;
+        index) data=("${MOCK_GPU_PCI_INDEX[@]}");;
         pci.domain) data=("${MOCK_GPU_PCI_DOMAINS[@]}");;
         serial) data=("${MOCK_GPU_PCI_SERIALS[@]}");;
         

--- a/Linux/test/nvidia-collection.bats
+++ b/Linux/test/nvidia-collection.bats
@@ -1,0 +1,133 @@
+#!/bin/usr/env bats
+# testing collection of nvidia diagnostics
+
+CUDA_PATH=/usr/local/cuda/samples/1_Utilities/bandwidthTest
+
+function setup {
+    load "test_helper/bats-support/load"
+    load "test_helper/bats-assert/load"
+    load ../src/gather_azhpc_vm_diagnostics.sh --no-update
+
+    DIAG_DIR=$(mktemp -d)
+    CUDA_SAMPLE_BW_DIR=$(mktemp -d)
+
+    function make {
+        if ! PARSED_OPTIONS=$(getopt -n "$0" -o C: --long 'directory:' -- "$@"); then
+            return 1
+        fi
+        eval set -- "$PARSED_OPTIONS"
+        local changed_dir
+
+        while [ "$1" != "--" ]; do
+            case "$1" in
+                -C|--directory) shift; changed_dir=true; pushd "$1" || return 1;;
+            esac
+            shift
+        done
+        
+        if [ "$1" == clean ]; then
+            rm ./bandwidthTest
+            touch ./make-cleaned
+        else
+            echo '#!/bin/bash' >./bandwidthTest
+            echo "echo 'CUDA bandwidth result goes here'" >>./bandwidthTest
+            chmod 700 ./bandwidthTest
+            touch ./make-built
+        fi
+
+        if [ "$changed_dir" == true ]; then
+            popd
+        fi
+    }
+}
+
+function teardown {
+    rm -rf "$DIAG_DIR"
+}
+
+@test "get_gpu_numa" {
+    run get_gpu_numa Standard_ND96asr_v4 -1
+    assert_failure
+    refute_output
+
+    run get_gpu_numa Standard_ND96asr_v4 0
+    assert_success
+    assert_output 0
+    
+    run get_gpu_numa Standard_ND96asr_v4 3
+    assert_success
+    assert_output 1
+    
+    run get_gpu_numa Standard_ND96asr_v4 7
+    assert_success
+    assert_output 3
+    
+    run get_gpu_numa Standard_ND96asr_v4 8
+    assert_failure
+    refute_output
+    
+    run get_gpu_numa Standard_ND40rs_v2 0
+    assert_failure
+    refute_output
+}
+
+@test "compile cuda samples" {
+    . "$BATS_TEST_DIRNAME/mocks.bash"
+    function make {
+        if [ "$2" == clean ]; then
+            rm "$CUDA_SAMPLE_BW_DIR/bandwidthTest"
+            touch "$CUDA_SAMPLE_BW_DIR/make-cleaned"
+        else
+            echo '#!/bin/bash' >"$CUDA_SAMPLE_BW_DIR/bandwidthTest"
+            echo "echo 'CUDA bandwidth result goes here'" >>"$CUDA_SAMPLE_BW_DIR/bandwidthTest"
+            chmod 700 "$CUDA_SAMPLE_BW_DIR/bandwidthTest"
+            touch "$CUDA_SAMPLE_BW_DIR/make-built"
+        fi
+    }
+
+    run run_cuda_bandwidth_test
+    assert [ -f "$CUDA_SAMPLE_BW_DIR/make-built" ]
+    assert [ -f "$CUDA_SAMPLE_BW_DIR/make-cleaned" ]
+}
+
+@test "fail gracefully when there are no cuda samples" {
+    rm -rf "$CUDA_SAMPLE_BW_DIR"
+    run run_cuda_bandwidth_test
+    assert_failure
+    refute_output
+}
+
+
+@test "fail gracefully when make is not installed" {
+    . "$BATS_TEST_DIRNAME/mocks.bash"
+    hide_command make
+    run run_cuda_bandwidth_test
+    assert_failure
+    refute_output
+}
+
+@test "run cuda samples" {
+    . "$BATS_TEST_DIRNAME/mocks.bash"
+    function make {
+        echo '#!/bin/bash' >"$CUDA_SAMPLE_BW_DIR/bandwidthTest"
+        echo 'echo "CUDA bandwidth result for device $CUDA_VISIBLE_DEVICES goes here"' >>"$CUDA_SAMPLE_BW_DIR/bandwidthTest"
+        chmod 700 "$CUDA_SAMPLE_BW_DIR/bandwidthTest"
+    }
+
+    function get_gpu_numa {
+        echo "0"
+    }
+
+    function numactl {
+        shift 2
+        $@
+    }
+
+    run run_cuda_bandwidth_test "Standard_ND96asr_v4"
+    assert_success
+    for i in {0..3}; do
+        run cat "$DIAG_DIR/Nvidia/bandwidthTest/$i.out"
+        assert_success
+        assert_output "CUDA bandwidth result for device $i goes here"
+    done
+}

--- a/Linux/test/nvidia-smi.bats
+++ b/Linux/test/nvidia-smi.bats
@@ -155,5 +155,5 @@ function teardown {
     assert_output --partial 'GPU not coming up in nvidia-smi'
     assert_output --partial 'BAD GPU'
     assert_output --partial '00000000-0000-0000-0000-00000000000a'
-
+    assert_output --partial '0000000000003'
 }

--- a/Linux/test/nvidia-smi.bats
+++ b/Linux/test/nvidia-smi.bats
@@ -202,14 +202,17 @@ function teardown {
     assert_success
 
     assert_line --index 1 --partial 'Underperforming in CUDA BW test'
+    assert_line --index 1 --partial 'Warning for GPU'
     assert_line --index 1 --partial '00000000-0000-0000-0000-000000000002'
     assert_line --index 1 --partial '0000000000002'
 
     assert_line --index 2 --partial 'Underperforming in CUDA BW test'
+    assert_line --index 1 --partial 'Warning for GPU'
     assert_line --index 2 --partial '00000000-0000-0000-0000-00000000000a'
     assert_line --index 2 --partial '0000000000003'
 
     assert_line --index 3 --partial 'Underperforming in CUDA BW test'
+    assert_line --index 1 --partial 'Warning for GPU'
     assert_line --index 3 --partial '00000000-0000-0000-0000-00000000000d'
     assert_line --index 3 --partial '0000000000004'
 

--- a/Linux/test/nvidia-smi.bats
+++ b/Linux/test/nvidia-smi.bats
@@ -130,6 +130,29 @@ function teardown {
     assert_equal "${#lines[@]}" 4
 }
 
+@test "detect row remap failure" {
+    . "$BATS_TEST_DIRNAME/mocks.bash"
+
+    sed -i 's|\[N/A\],00000001:00:00.0|0,00000001:00:00.0|g' "$NVIDIA_SMI_QUERY_GPU_DATA"
+    sed -i 's|\[N/A\],00000002:00:00.0|1,00000002:00:00.0|g' "$NVIDIA_SMI_QUERY_GPU_DATA"
+    sed -i 's|\[N/A\],0000000A:00:00.0|0,0000000A:00:00.0|g' "$NVIDIA_SMI_QUERY_GPU_DATA"
+    sed -i 's|\[N/A\],0000000D:00:00.0|1,0000000D:00:00.0|g' "$NVIDIA_SMI_QUERY_GPU_DATA"
+
+    run check_page_retirement
+
+    assert_success
+
+    assert_line --index 1 --partial 'Row Remap Failure'
+    assert_line --index 1 --partial '00000000-0000-0000-0000-000000000002'
+    assert_line --index 1 --partial '0000000000002'
+
+    assert_line --index 2 --partial 'Row Remap Failure'
+    assert_line --index 2 --partial '00000000-0000-0000-0000-00000000000d'
+    assert_line --index 2 --partial '0000000000004'
+
+    assert_equal "${#lines[@]}" 3
+}
+
 @test 'detect inforom warnings' {
     . "$BATS_TEST_DIRNAME/mocks.bash"
 

--- a/Linux/test/run_tests.sh
+++ b/Linux/test/run_tests.sh
@@ -116,6 +116,7 @@ sudo_basic_script_test() {
     for filename in $filenames; do
         if [[ "$filename" =~ ^Nvidia/stats_.*$ ]] ||
            [[ "$filename" =~ ^Nvidia/nvvs.log$ ]] ||
+           [[ "$filename" =~ ^Nvidia/bandwidthTest.*$ ]] ||
            [[ "$filename" =~ ^Infiniband/.* ]] ||
            [[ "$filename" =~ ^VM.* ]]; then
             continue # leave behavior for these undefined

--- a/Linux/test/samples/cudabw.csv
+++ b/Linux/test/samples/cudabw.csv
@@ -1,0 +1,11 @@
+[CUDA Bandwidth Test] - Starting...
+Running on...
+
+ Device 1: A100-SXM4-40GB
+ Quick Mode
+
+bandwidthTest-H2D-Pinned, Bandwidth = 25.7 GB/s, Time = 0.00124 s, Size = 32000000 bytes, NumDevsUsed = 1
+bandwidthTest-D2H-Pinned, Bandwidth = 21.8 GB/s, Time = 0.00147 s, Size = 32000000 bytes, NumDevsUsed = 1
+Result = PASS
+
+NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.

--- a/Linux/test/utils.bats
+++ b/Linux/test/utils.bats
@@ -1,0 +1,22 @@
+#!/bin/usr/env bats
+# testing various utility functions
+
+function setup {
+    load "test_helper/bats-support/load"
+    load "test_helper/bats-assert/load"
+    load ../src/gather_azhpc_vm_diagnostics.sh --no-update
+}
+
+@test "float_lt" {
+    run float_lt 16.2 17.8
+    assert_success
+    
+    run float_lt 20 16
+    assert_failure
+    
+    run float_lt 19.3 19.3
+    assert_failure
+    
+    run float_lt -19.3 18.0
+    assert_success
+}

--- a/Linux/test/utils.bats
+++ b/Linux/test/utils.bats
@@ -8,15 +8,135 @@ function setup {
 }
 
 @test "float_lt" {
-    run float_lt 16.2 17.8
+    run float_op 16.2 '<' 17.8
     assert_success
     
-    run float_lt 20 16
+    run float_op 20 '<' 16
     assert_failure
     
-    run float_lt 19.3 19.3
+    run float_op 19.3 '<' 19.3
     assert_failure
     
-    run float_lt -19.3 18.0
+    run float_op -19.3 '<' 18.0
     assert_success
+}
+
+@test "float_le" {
+    run float_op 16.2 '<=' 17.8
+    assert_success
+    
+    run float_op 20 '<=' 16
+    assert_failure
+    
+    run float_op 19.3 '<=' 19.3
+    assert_success
+    
+    run float_op -19.3 '<=' 18.0
+    assert_success
+}
+
+@test "float_gt" {
+    run float_op 16.2 '>' 17.8
+    assert_failure
+    
+    run float_op 20 '>' 16
+    assert_success
+    
+    run float_op 19.3 '>' 19.3
+    assert_failure
+    
+    run float_op -19.3 '>' 18.0
+    assert_failure
+}
+
+@test "float_ge" {
+    run float_op 16.2 '>=' 17.8
+    assert_failure
+    
+    run float_op 20 '>=' 16
+    assert_success
+    
+    run float_op 19.3 '>=' 19.3
+    assert_success
+    
+    run float_op -19.3 '>=' 18.0
+    assert_failure
+}
+
+@test "float_eq" {
+    run float_op 0 == 0
+    assert_success
+
+    run float_op -4 == -4
+    assert_success
+
+    run float_op 4 == 2
+    assert_failure
+    
+    run float_op 3.2 == 3
+    assert_failure
+
+    run float_op 1.0 == 1
+    assert_success
+}
+
+@test "float_ne" {
+    run float_op 0 != 0
+    assert_failure
+
+    run float_op -4 != -4
+    assert_failure
+
+    run float_op 4 != 2
+    assert_success
+
+    run float_op 3.2 != 3
+    assert_success
+
+    run float_op 1.0 != 1
+    assert_failure
+}
+
+@test "float_add" {
+    run float_op 1 + 1
+    assert_output 2.000000
+
+    run float_op -1 + 1
+    assert_output 0.000000
+
+    run float_op 0.3 + 0.6
+    assert_output 0.900000
+}
+
+@test "float_sub" {
+    run float_op 1 - 1
+    assert_output 0.000000
+
+    run float_op 1 - -1
+    assert_output 2.000000
+
+    run float_op 0.3 - 0.6
+    assert_output -0.300000
+}
+
+@test "float_mul" {
+    run float_op 1 '*' 1
+    assert_output 1.000000
+
+    run float_op 1 '*' -1
+    assert_output -1.000000
+
+    run float_op 0.3 '*' 0.6
+    assert_output 0.180000
+}
+
+@test "float_div" {
+    run float_op 1 '/' 1
+    assert_output 1.000000
+
+    run float_op 1 '/' -1
+    assert_output -1.000000
+
+    run float_op 0.3 '/' 0.6
+    assert_output 0.500000
 }

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Note that not all these files will be generated on all runs. What appears below 
 |   -- ibv_devinfo.txt
 |   -- pkeys/*
 |-- Nvidia
+    -- bandwidthTest/*.csv
     -- nvidia-bug-report.log.gz
     -- nvidia-vmext.log
     -- nvidia-smi.out
@@ -122,6 +123,7 @@ Note that not all these files will be generated on all runs. What appears below 
 | NVIDIA System Management Interface | nvidia-smi | Nvidia/nvidia-smi.out Nvidia/nvidia-smi-q.out | Checks GPU health and configuration | [CUDA EULA](https://docs.nvidia.com/cuda/pdf/EULA.pdf) [GRID EULA](https://images.nvidia.com/content/pdf/grid/support/enterprise-eula-grid-and-amgx-supplements.pdf) |
 | NVIDIA Debug Dump | nvidia-debugbump | Nvidia/nvidia-debugdump.zip | Generates a binary blob for use with Nvidia internal engineering tools | [CUDA EULA](https://docs.nvidia.com/cuda/pdf/EULA.pdf) [GRID EULA](https://images.nvidia.com/content/pdf/grid/support/enterprise-eula-grid-and-amgx-supplements.pdf) |
 | NVIDIA Data Center GPU Manager | dcgmi | Nvidia/dcgm-diag-2.log Nvidia/dcgm-diag-3.log Nvidia/nvvs.log Nvidia/stats_*.json | Health monitoring for GPUs in cluster environments | [DCGM EULA](https://developer.download.nvidia.com/compute/DCGM/docs/EULA.pdf) |
+| CUDA Bandwidth Test | /usr/local/cuda/samples/1_Utilities/bandwidthTest/bandwidthTest | Nvidia/bandwidthTest/*.csv | Runs the CUDA Samples' Bandwidth Test | [CUDA EULA](https://docs.nvidia.com/cuda/pdf/EULA.pdf) |
 | GPU Driver Extension Logs | cp /var/log/azure/nvidia-vmext-status | Nvidia/nvidia-vmext-status | Logs from the GPU Driver Extension | |
 
 


### PR DESCRIPTION
The focus of this PR is to enable the script to be used to diagnose common issues on the NDv4 VM size.

The primary new feature is a pair of checks that investigate the current performance of PCI links to GPUs. The first is based directly on PCI link information reported by lspci, and the second uses the CUDA Sample Bandwidth Test that gets installed with CUDA to view performance from an application's perspective.

To further support the A100 VM size, this PR also includes a fix to filter out Nvidia bridges and focus on GPUs when querying for pci devices, and it updates the existing page retirement checks to support GPUs that use [row remapping](https://docs.nvidia.com/deploy/a100-gpu-mem-error-mgmt/index.html#:~:text=Row-remapping%20is%20a%20hardware%20mechanism%20to%20improve%20the,page%20retirement%20scheme%20used%20in%20prior%20generation%20GPUs.), Nvidia's new version of page retirement introduced on the A100.