### PR TITLE
Filters out AN Ethernet interfaces for ibstat and pkey collection

### DIFF
--- a/Linux/src/gather_azhpc_vm_diagnostics.sh
+++ b/Linux/src/gather_azhpc_vm_diagnostics.sh
@@ -66,7 +66,7 @@ GPU_PCI_CLASS_ID=0302
 declare -A CPU_LIST
 CPU_LIST=(["Standard_HB120rs_v2"]="0 1,5,9,13,17,21,25,29,33,37,41,45,49,53,57,61,65,69,73,77,81,85,89,93,97,101,105,109,113,117"
           ["Standard_HB60rs"]="0 1,5,9,13,17,21,25,29,33,37,41,45,49,53,57")
-RELEASE_DATE=20210927 # update upon each release
+RELEASE_DATE=20211028 # update upon each release
 COMMIT_HASH=$( 
     (
         cd "$SCRIPT_DIR" &&
@@ -407,7 +407,6 @@ run_infiniband_diags() {
         print_log -e "\tQuerying Infiniband device status, writing to {output}/Infiniband/ibstatus.out"
         ibstatus > "$DIAG_DIR/Infiniband/ibstatus.out"
 
-        local ib_interfaces
         ib_interfaces=$(
             awk '
             /Infiniband device/ { device_name=$3 }
@@ -429,12 +428,13 @@ run_infiniband_diags() {
     fi
 
     print_log -e "\tChecking for Infiniband pkeys"
-    for dir in "$SYSFS_PATH"/class/infiniband/*; do
-        [ -d "$dir" ] || continue
-
-        print_log -e "\tChecking for Infiniband pkeys in $dir"
-        local device
-        device=$(basename "$dir")
+    for device in $ib_interfaces; do
+        local dir="$SYSFS_PATH/class/infiniband/$device"
+        if ! [ -d "$dir" ]; then
+            print_log "\tDevice $device not showing up in $SYSFS_PATH/class/infiniband/"
+        else
+            print_log -e "\tChecking for Infiniband pkeys in $dir"
+        fi
         mkdir -p "$DIAG_DIR/Infiniband/$device/pkeys"
 
         local pkey_count

--- a/Linux/test/compatibility.bats
+++ b/Linux/test/compatibility.bats
@@ -167,6 +167,21 @@ function setup() {
     done
 }
 
+@test "Confirm that ibstatus output has device name lines followed by link_layer lines as expected" {
+    if ! ibstatus >/dev/null 2>/dev/null; then
+        skip "no functioning installation of lspci"
+    fi
+
+    run awk '
+        BEGIN { expecting="devicename"}
+        /Infiniband device/ { if (expecting != "devicename") {exit(1)} else { expecting="link_layer"} }
+        /link_layer:\s+(Ethernet|InfiniBand)/ { if (expecting != "link_layer") {exit(1)} else { expecting="devicename"} }
+        END { if (expecting != "devicename") { exit(1) } }
+    ' <(ibstatus)
+
+    assert_success
+}
+
 @test "Confirm that pkeys are where we think" {
     if ! [ -d /sys/class/infiniband ]; then
         skip "no infiniband section of sysfs"

--- a/Linux/test/infiniband.bats
+++ b/Linux/test/infiniband.bats
@@ -11,13 +11,10 @@ function setup {
 
     SYSFS_PATH=$(mktemp -d)
     
-    local IB_DEVICES_PATH="$SYSFS_PATH/class/infiniband"
-    mkdir -p "$IB_DEVICES_PATH/mlx4_0/ports/1/pkeys"
-    echo 0xffff > "$IB_DEVICES_PATH/mlx4_0/ports/1/pkeys/0"
-    echo 0x0001 > "$IB_DEVICES_PATH/mlx4_0/ports/1/pkeys/1"
-    mkdir -p "$IB_DEVICES_PATH/mlx5_1/ports/1/pkeys"
-    echo 0xffff > "$IB_DEVICES_PATH/mlx5_1/ports/1/pkeys/0"
-    echo 0x0001 > "$IB_DEVICES_PATH/mlx5_1/ports/1/pkeys/1"
+    IB_DEVICES_PATH="$SYSFS_PATH/class/infiniband"
+    mkdir -p "$IB_DEVICES_PATH/mlx5_ib0/ports/1/pkeys"
+    echo 0xffff > "$IB_DEVICES_PATH/mlx5_ib0/ports/1/pkeys/0"
+    echo 0x0001 > "$IB_DEVICES_PATH/mlx5_ib0/ports/1/pkeys/1"
 }
 
 function teardown {
@@ -25,14 +22,16 @@ function teardown {
 }
 
 @test "Confirm that pkeys get collected" {
+    . "$BATS_TEST_DIRNAME/mocks.bash"
+
     run run_infiniband_diags
     assert_success
 
-    run cat "$DIAG_DIR/Infiniband/mlx4_0/pkeys/0"
+    run cat "$DIAG_DIR/Infiniband/mlx5_ib0/pkeys/0"
     assert_success
     assert_output 0xffff
 
-    run cat "$DIAG_DIR/Infiniband/mlx4_0/pkeys/1"
+    run cat "$DIAG_DIR/Infiniband/mlx5_ib0/pkeys/1"
     assert_success
     assert_output 0x0001
 }
@@ -122,17 +121,8 @@ function teardown {
     run check_pkeys
     refute_output
 
-    rm "$DIAG_DIR/Infiniband/mlx4_0/pkeys/0"
+    rm "$DIAG_DIR/Infiniband/mlx5_ib0/pkeys/0"
     run check_pkeys
-    assert_output --partial "Could not find pkey 0 for device mlx4_0"
-    refute_output --partial "Could not find pkey 1 for device mlx4_0"
-    refute_output --partial "Could not find pkey 0 for device mlx5_1"
-    refute_output --partial "Could not find pkey 1 for device mlx5_1"
-
-    rm "$DIAG_DIR/Infiniband/mlx5_1/pkeys/1"
-    run check_pkeys
-    assert_output --partial "Could not find pkey 0 for device mlx4_0"
-    refute_output --partial "Could not find pkey 1 for device mlx4_0"
-    refute_output --partial "Could not find pkey 0 for device mlx5_1"
-    assert_output --partial "Could not find pkey 1 for device mlx5_1"
+    assert_output --partial "Could not find pkey 0 for device mlx5_ib0"
+    refute_output --partial "Could not find pkey 1 for device mlx5_ib0"
 }

--- a/Linux/test/infiniband.bats
+++ b/Linux/test/infiniband.bats
@@ -43,13 +43,32 @@ function teardown {
     run run_infiniband_diags
     assert_success
 
-    run cat "$DIAG_DIR/Infiniband/ibstat.txt"
+    run cat "$DIAG_DIR/Infiniband/ibstatus.out"
     assert_success
     assert_output
 
-    run cat "$DIAG_DIR/Infiniband/ibv_devinfo.txt"
+    run cat "$DIAG_DIR/Infiniband/ibstat.out"
+    assert_success
+    assert_output
+
+    run cat "$DIAG_DIR/Infiniband/ibv_devinfo.out"
     assert_success
     assert_output "full output"
+}
+
+@test "Confirm that lack of ibstatus is noticed" {
+    . "$BATS_TEST_DIRNAME/mocks.bash"
+
+    hide_command ibstatus
+
+    run run_infiniband_diags
+    assert_success
+
+    assert_output --partial "No Infiniband Driver Detected"
+
+    refute [ -f "$DIAG_DIR/Infiniband/ibstatus.out" ]
+    refute [ -f "$DIAG_DIR/Infiniband/ibstat.out" ]
+    refute [ -f "$DIAG_DIR/Infiniband/ibv_devinfo.out" ]
 }
 
 @test "Confirm that lack of ibstat is noticed" {
@@ -60,10 +79,11 @@ function teardown {
     run run_infiniband_diags
     assert_success
 
-    assert_output --partial "No Infiniband Driver Detected"
+    assert_output --partial "ibstat not found"
 
-    refute [ -f "$DIAG_DIR/Infiniband/ibstat.txt" ]
-    refute [ -f "$DIAG_DIR/Infiniband/ibv_devinfo.txt" ]
+    assert [ -f "$DIAG_DIR/Infiniband/ibstatus.out" ]
+    refute [ -f "$DIAG_DIR/Infiniband/ibstat.out" ]
+    assert [ -f "$DIAG_DIR/Infiniband/ibv_devinfo.out" ]
 }
 
 @test "Confirm that ib-vmext-status gets collected" {

--- a/Linux/test/mocks.bash
+++ b/Linux/test/mocks.bash
@@ -117,6 +117,10 @@ function ibstat {
     echo "infiniband results"
 }
 
+function ibstatus {
+    cat "$BATS_TEST_DIRNAME/samples/ibstatus.out"
+}
+
 function ibv_devinfo {
     if [ "$1" == "-v" ]; then
         echo "full output"

--- a/Linux/test/run_tests.sh
+++ b/Linux/test/run_tests.sh
@@ -43,8 +43,9 @@ DCGM_FILENAMES="Nvidia/dcgm-diag.log"
 MEMORY_FILENAMES="Memory/
 Memory/stream.txt"
 
-INFINIBAND_FILENAMES="Infiniband/ibstat.txt
-Infiniband/ibv_devinfo.txt"
+INFINIBAND_FILENAMES="Infiniband/ibstat.out
+Infiniband/ibstatus.out
+Infiniband/ibv_devinfo.out"
 
 INFINIBAND_EXT_FILENAMES="Infiniband/ib-vmext-status"
 

--- a/Linux/test/samples/ibstatus.out
+++ b/Linux/test/samples/ibstatus.out
@@ -1,0 +1,18 @@
+Infiniband device 'mlx5_an0' port 1 status:
+        default gid:     unknown
+        base lid:        0x0
+        sm lid:          0x0
+        state:           4: ACTIVE
+        phys state:      5: LinkUp
+        rate:            40 Gb/sec (4X QDR)
+        link_layer:      Ethernet
+
+Infiniband device 'mlx5_ib0' port 1 status:
+        default gid:     fe80:0000:0000:0000:0015:5dff:fd33:ff0b
+        base lid:        0x96
+        sm lid:          0x11c
+        state:           4: ACTIVE
+        phys state:      5: LinkUp
+        rate:            200 Gb/sec (4X HDR)
+        link_layer:      InfiniBand
+        

--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ Note that not all these files will be generated on all runs. What appears below 
 |   -- stream.txt
 |-- Infiniband
 |   -- ib-vmext.log
-|   -- ibstat.txt
-|   -- ibv_devinfo.txt
+|   -- ibstat.out
+|   -- ibstatus.out
+|   -- ibv_devinfo.out
 |   -- pkeys/*
 |-- Nvidia
     -- nvidia-bug-report.log.gz
@@ -126,8 +127,9 @@ Note that not all these files will be generated on all runs. What appears below 
 | lsmod | lsmod | VM/lsmod.txt | List of active kernel modules | |
 | lscpu | lscpu | CPU/lscpu.txt | Information about the system CPU architecture | |
 | stream | stream_zen_double | Memory/stream.txt | The stream benchmark suite (AMD Only) | [Stream License](http://www.cs.virginia.edu/stream/FTP/Code/LICENSE.txt)
-| ibstat | ibstat | Infiniband/ibstat.txt | Mellanox OFED command for checking Infiniband status | [MOFED End-User Agreement](https://www.mellanox.com/page/mlnx_ofed_eula#:~:text=11%20Mellanox%20OFED%20Software%3A%20Third%20Party%20Free%20Software,2-clause%20FreeBSD%20License%20%2018%20more%20rows%20) |
-| ibv_devinfo | ibv_devinfo | Infiniband/ibv_devinfo.txt | Mellanox OFED commnd for checking Infiniband Device info | [MOFED End-User Agreement](https://www.mellanox.com/page/mlnx_ofed_eula#:~:text=11%20Mellanox%20OFED%20Software%3A%20Third%20Party%20Free%20Software,2-clause%20FreeBSD%20License%20%2018%20more%20rows%20) |
+| ibstat | ibstat | Infiniband/ibstat.out | Mellanox OFED command for checking Infiniband status | [MOFED End-User Agreement](https://www.mellanox.com/page/mlnx_ofed_eula#:~:text=11%20Mellanox%20OFED%20Software%3A%20Third%20Party%20Free%20Software,2-clause%20FreeBSD%20License%20%2018%20more%20rows%20) |
+| ibstatus | ibstatus | Infiniband/ibstat.out | Lightweight Mellanox OFED command for checking Infiniband status | [MOFED End-User Agreement](https://www.mellanox.com/page/mlnx_ofed_eula#:~:text=11%20Mellanox%20OFED%20Software%3A%20Third%20Party%20Free%20Software,2-clause%20FreeBSD%20License%20%2018%20more%20rows%20) |
+| ibv_devinfo | ibv_devinfo | Infiniband/ibv_devinfo.out | Mellanox OFED commnd for checking Infiniband Device info | [MOFED End-User Agreement](https://www.mellanox.com/page/mlnx_ofed_eula#:~:text=11%20Mellanox%20OFED%20Software%3A%20Third%20Party%20Free%20Software,2-clause%20FreeBSD%20License%20%2018%20more%20rows%20) |
 | Partition Key | cp /sys/class/infiniband/.../pkeys/... | Infiniband/.../pkeys/... | Checks the configured Infinband Partition Keys |
 | Infiniband Driver Extension Logs | cp /var/log/azure/ib-vmext-status | Infiniband/ib-vmext-status | Logs from the Infiniband Driver Extension |
 | NVIDIA Bug Report | nvidia-bug-report.sh | Nvidia/nvidia-bug-report.log.gz | A script that Nvidia has customers run when reporting hardware problems. | [CUDA EULA](https://docs.nvidia.com/cuda/pdf/EULA.pdf) [GRID EULA](https://images.nvidia.com/content/pdf/grid/support/enterprise-eula-grid-and-amgx-supplements.pdf) |


### PR DESCRIPTION
This is meant to address #59 
But also uses the filtered list of IB interfaces to look for pkeys.