### PR TITLE
filter out NCv2/3 for ENDURE checks

### DIFF
--- a/Linux/src/gather_azhpc_vm_diagnostics.sh
+++ b/Linux/src/gather_azhpc_vm_diagnostics.sh
@@ -175,7 +175,7 @@ is_infiniband_sku() {
 }
 
 is_endure_sku() {
-    echo "$1" | grep -Eiq '^Standard_(H16m?r|NC24r)'
+    echo "$1" | grep -Eiq '^Standard_(H16m?r|NC24rs?)$'
 }
 
 is_nvidia_sku() {

--- a/Linux/src/gather_azhpc_vm_diagnostics.sh
+++ b/Linux/src/gather_azhpc_vm_diagnostics.sh
@@ -72,7 +72,7 @@ GPU_PCI_CLASS_ID=0302
 declare -A CPU_LIST
 CPU_LIST=(["Standard_HB120rs_v2"]="0 1,5,9,13,17,21,25,29,33,37,41,45,49,53,57,61,65,69,73,77,81,85,89,93,97,101,105,109,113,117"
           ["Standard_HB60rs"]="0 1,5,9,13,17,21,25,29,33,37,41,45,49,53,57")
-RELEASE_DATE=20211104 # update upon each release
+RELEASE_DATE=20211108 # update upon each release
 COMMIT_HASH=$( 
     (
         command -v git >/dev/null &&

--- a/Linux/test/vmsizes.bats
+++ b/Linux/test/vmsizes.bats
@@ -45,6 +45,10 @@ function setup {
     run is_endure_sku Standard_NC24rs
     assert_success
     refute_output
+    
+    run is_endure_sku Standard_NC24rs_v3
+    assert_failure
+    refute_output
 
     run is_endure_sku Standard_H16r
     assert_success


### PR DESCRIPTION
Fixes a bug that leads to mis-identifying NC24 v2 and v3 sizes as non-SRIOV if they don't have IB drivers installed.