### PR TITLE
Add version increment GH Actions Workflow

### DIFF
--- a/.github/workflows/increment_version.yml
+++ b/.github/workflows/increment_version.yml
@@ -1,0 +1,38 @@
+name: Increment HPCDiag version number
+on:
+  push:
+    branches:
+      - main
+jobs:
+  increment_version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: increment version number in main script
+        run: |
+          last_versioned_commit=$(git blame Linux/src/gather_azhpc_vm_diagnostics.sh | grep RELEASE_DATE= | cut -d' ' -f1)
+          if ! git diff --exit-code "$last_versioned_commit" -- Linux/src/gather_azhpc_vm_diagnostics.sh; then
+            old_date=$(awk '/RELEASE_DATE=/{print $1}' Linux/src/gather_azhpc_vm_diagnostics.sh | cut -d= -f2)
+            today=$(date +%Y%m%d)
+            new_version=$(case "$old_date" in
+              "$today") echo -n "$today-01" ;;
+              "$today-"*) 
+                old_minor=$(echo "$old_date" | cut -d- -f2)
+                printf "%d-%02d" "$today" $((old_minor + 1))
+                ;;
+              *) echo -n "$today" ;;
+            esac)
+
+            sed -E -i "s/RELEASE_DATE=[0-9]+(-[0-9]+)?/RELEASE_DATE=$new_version/g" Linux/src/gather_azhpc_vm_diagnostics.sh
+
+            git config user.name "GitHub Actions Bot"
+            git config user.email "<>"
+            
+            git add Linux/src/gather_azhpc_vm_diagnostics.sh
+            git commit -m "increment version number"
+            git push
+          fi

--- a/.github/workflows/increment_version.yml
+++ b/.github/workflows/increment_version.yml
@@ -17,7 +17,7 @@ jobs:
           last_versioned_commit=$(git blame Linux/src/gather_azhpc_vm_diagnostics.sh | grep RELEASE_DATE= | cut -d' ' -f1)
           if ! git diff --exit-code "$last_versioned_commit" -- Linux/src/gather_azhpc_vm_diagnostics.sh; then
             old_date=$(awk '/RELEASE_DATE=/{print $1}' Linux/src/gather_azhpc_vm_diagnostics.sh | cut -d= -f2)
-            today=$(date +%Y%m%d)
+            today=$(date --utc +%Y%m%d)
             new_version=$(case "$old_date" in
               "$today") echo -n "$today-01" ;;
               "$today-"*) 


### PR DESCRIPTION
The workflow is set to be triggered whenever there's a change to main, whether it be a direct push (shouldn't be possible) or a PR.

It checks to see if the main script has been changed more recently than its version number. If so, it generates a new version number and commits it.

Normally the new version number will be YYYYMMDD for the current date, but in the event of multiple pushed in a single day, it'll be set to YYYYMMDD-01, YYYYMMDD-02 and so on.