### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,34 +1,35 @@
 {
-    "Registrations": [
-        {
-            "Component": {
-                "Type": "git",
-                "git": { 
-                    "RepositoryUrl": "https://github.com/bats-core/bats-core",
-                    "CommitHash": "b81de286448ae3a11e3342783dcdc1b08765a421"
-                }
-            },
-            "DevelopmentDependency": true
-        },
-        {
-            "Component": {
-                "Type": "git",
-                "git": { 
-                    "RepositoryUrl": "https://github.com/bats-core/bats-support",
-                    "CommitHash": "d140a65044b2d6810381935ae7f0c94c7023c8c3"
-                }
-            },
-            "DevelopmentDependency": true
-        },
-        {
-            "Component": {
-                "Type": "git",
-                "git": { 
-                    "RepositoryUrl": "https://github.com/bats-core/bats-assert",
-                    "CommitHash": "0a8dd57e2cc6d4cc064b1ed6b4e79b9f7fee096f"
-                }
-            },
-            "DevelopmentDependency": true
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "git",
+        "git": {
+          "RepositoryUrl": "https://github.com/bats-core/bats-core",
+          "CommitHash": "b81de286448ae3a11e3342783dcdc1b08765a421"
         }
-    ]
+      },
+      "DevelopmentDependency": true
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "git": {
+          "RepositoryUrl": "https://github.com/bats-core/bats-support",
+          "CommitHash": "d140a65044b2d6810381935ae7f0c94c7023c8c3"
+        }
+      },
+      "DevelopmentDependency": true
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "git": {
+          "RepositoryUrl": "https://github.com/bats-core/bats-assert",
+          "CommitHash": "0a8dd57e2cc6d4cc064b1ed6b4e79b9f7fee096f"
+        }
+      },
+      "DevelopmentDependency": true
+    }
+  ]
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.